### PR TITLE
Flatten output structure and improve CLI intuitiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## [0.8.0] - Unreleased
+
+### Changed (Breaking)
+- **Flattened directory structure**: Dependencies now at `target/doc-md/crate/` instead of `target/doc-md/deps/crate/`
+- **CLI redesign**: Positional args now accept crate names instead of JSON paths
+  - Old: `cargo doc-md --deps tokio,serde`
+  - New: `cargo doc-md tokio serde`
+- **JSON conversion**: Now requires explicit `--json` flag
+  - Old: `cargo doc-md file.json`
+  - New: `cargo doc-md --json file.json`
+
+### Added
+- Automatic migration from old `deps/` structure on first run
+- Nightly toolchain validation with helpful error messages
+- Flag conflict validation (e.g., `--json` + crate names)
+- Better error messages with actionable suggestions
+- CLI integration tests
+
+### Fixed
+- Root package lookup now uses `resolve.root` (correct for workspaces)
+- Stderr shown on build failures (was suppressed)
+- Master index now generated in all code paths
+
+### Migration from 0.7.x
+Tool auto-migrates on first run. Update scripts:
+- Replace `--deps crate1,crate2` with `crate1 crate2`
+- Replace `cargo doc-md file.json` with `cargo doc-md --json file.json`
+- Update file paths: `deps/crate/` → `crate/`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-doc-md"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-doc-md"
-version = "0.7.5"
+version = "0.8.0"
 edition = "2024"
 authors = ["Claude (Anthropic AI) <noreply@anthropic.com>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ Run `cargo doc-md --help` for detailed information.
 
 Requires Rust nightly.
 
+## Upgrading from 0.7.x
+
+**Breaking changes** in 0.8.0:
+- Directory structure flattened: `deps/crate/` → `crate/`
+- CLI changed: `--deps tokio,serde` → `tokio serde`
+- JSON conversion: now requires `--json` flag
+
+Tool auto-migrates old structure on first run. Update your scripts accordingly.
+
 ## Development
 
 This project uses snapshot testing to ensure output quality and consistency. Run tests with:

--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ cargo doc-md
 # Document only dependencies
 cargo doc-md --all-deps
 
-# Document specific dependencies
-cargo doc-md --deps tokio,axum
+# Document specific crates
+cargo doc-md tokio serde axum
 
 # Custom output directory
 cargo doc-md -o docs/
+
+# Convert existing rustdoc JSON
+cargo doc-md --json target/doc/my_crate.json
 ```
 
 ### Output Structure
@@ -37,11 +40,12 @@ target/doc-md/
     module2.md
     sub/
       nested_module.md
-  deps/
-    tokio/
-      index.md
-      io.md
-      net.md
+  tokio/
+    index.md
+    io.md
+    net.md
+  serde/
+    index.md
     ...
 ```
 
@@ -66,14 +70,17 @@ target/doc-md/
 ## Options
 
 ```
-cargo doc-md [OPTIONS] [INPUT]
+cargo doc-md [OPTIONS] [CRATES...]
+
+Arguments:
+  [CRATES...]               Specific crate(s) to document (omit for current crate + all deps)
 
 Options:
   -o, --output <DIR>        Output directory [default: target/doc-md]
       --all-deps            Document only dependencies (exclude current crate)
-      --deps <CRATES>       Document specific dependencies (comma-separated)
       --include-private     Include private items
-  -h, --help               Show help
+      --json <FILE>         Convert existing rustdoc JSON file
+  -h, --help                Show help
 ```
 
 Run `cargo doc-md --help` for detailed information.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A Cargo subcommand that generates markdown documentation for Rust crates and the
 
 ## Installation
 
+**Requires Rust nightly** (uses unstable rustdoc features):
 ```bash
+rustup install nightly
 cargo install cargo-doc-md
 ```
 
@@ -84,8 +86,6 @@ Options:
 ```
 
 Run `cargo doc-md --help` for detailed information.
-
-Requires Rust nightly.
 
 ## Upgrading from 0.7.x
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,11 +90,10 @@ fn main() -> Result<()> {
             .file_stem()
             .and_then(|s| s.to_str())
             .context("Invalid JSON filename - could not extract crate name")?;
-        println!(
-            "✓ Conversion complete! Output written to: {}/{}/index.md",
-            cli.output.display(),
-            crate_name
-        );
+
+        // Generate master index for consistency with other modes
+        generate_master_index(&cli.output, None, &[crate_name.to_string()])?;
+
         return Ok(());
     }
 

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -1,0 +1,136 @@
+use std::process::Command;
+use std::fs;
+use std::path::PathBuf;
+
+fn run_cargo_doc_md(args: &[&str]) -> Result<String, String> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("run").arg("--").args(args);
+
+    let output = cmd.output().expect("Failed to execute command");
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).to_string())
+    }
+}
+
+#[test]
+fn test_flag_validation_json_with_crates() {
+    let result = run_cargo_doc_md(&["--json", "test.json", "tokio"]);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("Cannot specify crate names with --json"));
+}
+
+#[test]
+fn test_flag_validation_all_deps_with_crates() {
+    let result = run_cargo_doc_md(&["--all-deps", "tokio"]);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("Cannot use --all-deps with specific crate names"));
+}
+
+#[test]
+fn test_json_validation_file_not_found() {
+    let result = run_cargo_doc_md(&["--json", "nonexistent_file_12345.json"]);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("JSON file not found"));
+}
+
+#[test]
+fn test_json_validation_path_is_directory() {
+    // Create a temporary directory
+    let temp_dir = std::env::temp_dir().join("cargo_doc_md_test_dir");
+    fs::create_dir_all(&temp_dir).unwrap();
+
+    let result = run_cargo_doc_md(&["--json", temp_dir.to_str().unwrap()]);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("Path is not a file"));
+
+    // Cleanup
+    fs::remove_dir(&temp_dir).ok();
+}
+
+#[test]
+fn test_migration_cleanup_behavior() {
+    // Create old deps/ structure
+    let output_dir = PathBuf::from("target/doc-md-test-migration");
+    let deps_dir = output_dir.join("deps");
+
+    // Clean up from any previous test runs
+    fs::remove_dir_all(&output_dir).ok();
+
+    // Create old structure
+    fs::create_dir_all(&deps_dir).unwrap();
+    fs::write(deps_dir.join("test.txt"), "test content").unwrap();
+
+    // Run with custom output directory and --all-deps to avoid needing current crate
+    let result = run_cargo_doc_md(&["-o", output_dir.to_str().unwrap(), "--all-deps"]);
+
+    // Print error for debugging
+    if let Err(ref e) = result {
+        eprintln!("Migration test error: {}", e);
+    }
+
+    // Should succeed and deps/ should be removed
+    // Note: May fail if no dependencies exist, which is acceptable
+    // The important part is that deps/ is cleaned up
+    if deps_dir.exists() {
+        // Check if there was a migration message
+        if let Ok(stdout) = result {
+            assert!(stdout.contains("Migrated to new flat structure") || stdout.contains("Cleaning up old directory"));
+        }
+    }
+
+    // Cleanup
+    fs::remove_dir_all(&output_dir).ok();
+}
+
+#[test]
+fn test_help_output() {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("run").arg("--").arg("--help");
+
+    let output = cmd.output().expect("Failed to execute command");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Combine both streams as help might be in either
+    let combined = format!("{}{}", stdout, stderr);
+
+    assert!(output.status.success());
+    assert!(combined.contains("Generate markdown documentation") || combined.contains("Cargo subcommand"));
+    assert!(combined.contains("--json"));
+    assert!(combined.contains("--all-deps"));
+    assert!(combined.contains("--output") || combined.contains("-o,"));
+}
+
+#[test]
+fn test_nightly_requirement_message() {
+    // This test may fail on systems without nightly, which is expected behavior
+    // It verifies the error message is helpful
+
+    // We can't easily test the nightly check without manipulating PATH,
+    // but we can at least verify the code compiles and the check exists
+    // The actual validation will happen in real usage
+}
+
+#[test]
+fn test_output_directory_creation() {
+    let output_dir = PathBuf::from("target/doc-md-test-creation");
+
+    // Clean up from previous runs
+    fs::remove_dir_all(&output_dir).ok();
+
+    // Verify directory doesn't exist
+    assert!(!output_dir.exists());
+
+    // Run and expect output directory to be created
+    // Using --all-deps to avoid needing to generate current crate docs
+    let _result = run_cargo_doc_md(&["-o", output_dir.to_str().unwrap()]);
+
+    // Directory should now exist (even if command failed for other reasons)
+    // The converter creates the directory
+
+    // Cleanup
+    fs::remove_dir_all(&output_dir).ok();
+}

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -19,14 +19,14 @@ fn run_cargo_doc_md(args: &[&str]) -> Result<String, String> {
 fn test_flag_validation_json_with_crates() {
     let result = run_cargo_doc_md(&["--json", "test.json", "tokio"]);
     assert!(result.is_err());
-    assert!(result.unwrap_err().contains("Cannot specify crate names with --json"));
+    assert!(result.unwrap_err().contains("Cannot use crate names with --json"));
 }
 
 #[test]
 fn test_flag_validation_all_deps_with_crates() {
     let result = run_cargo_doc_md(&["--all-deps", "tokio"]);
     assert!(result.is_err());
-    assert!(result.unwrap_err().contains("Cannot use --all-deps with specific crate names"));
+    assert!(result.unwrap_err().contains("Cannot use --all-deps with specific crates"));
 }
 
 #[test]
@@ -52,36 +52,19 @@ fn test_json_validation_path_is_directory() {
 
 #[test]
 fn test_migration_cleanup_behavior() {
-    // Create old deps/ structure
     let output_dir = PathBuf::from("target/doc-md-test-migration");
     let deps_dir = output_dir.join("deps");
 
-    // Clean up from any previous test runs
     fs::remove_dir_all(&output_dir).ok();
-
-    // Create old structure
     fs::create_dir_all(&deps_dir).unwrap();
     fs::write(deps_dir.join("test.txt"), "test content").unwrap();
 
-    // Run with custom output directory and --all-deps to avoid needing current crate
-    let result = run_cargo_doc_md(&["-o", output_dir.to_str().unwrap(), "--all-deps"]);
+    // Run - may succeed or fail, but deps/ should be cleaned up
+    let _ = run_cargo_doc_md(&["-o", output_dir.to_str().unwrap(), "--all-deps"]);
 
-    // Print error for debugging
-    if let Err(ref e) = result {
-        eprintln!("Migration test error: {}", e);
-    }
+    // The key assertion: old deps/ directory should be removed
+    assert!(!deps_dir.exists(), "Old deps/ directory should be cleaned up on any run");
 
-    // Should succeed and deps/ should be removed
-    // Note: May fail if no dependencies exist, which is acceptable
-    // The important part is that deps/ is cleaned up
-    if deps_dir.exists() {
-        // Check if there was a migration message
-        if let Ok(stdout) = result {
-            assert!(stdout.contains("Migrated to new flat structure") || stdout.contains("Cleaning up old directory"));
-        }
-    }
-
-    // Cleanup
     fs::remove_dir_all(&output_dir).ok();
 }
 
@@ -105,32 +88,17 @@ fn test_help_output() {
 }
 
 #[test]
-fn test_nightly_requirement_message() {
-    // This test may fail on systems without nightly, which is expected behavior
-    // It verifies the error message is helpful
-
-    // We can't easily test the nightly check without manipulating PATH,
-    // but we can at least verify the code compiles and the check exists
-    // The actual validation will happen in real usage
-}
-
-#[test]
 fn test_output_directory_creation() {
     let output_dir = PathBuf::from("target/doc-md-test-creation");
 
-    // Clean up from previous runs
     fs::remove_dir_all(&output_dir).ok();
-
-    // Verify directory doesn't exist
     assert!(!output_dir.exists());
 
-    // Run and expect output directory to be created
-    // Using --all-deps to avoid needing to generate current crate docs
-    let _result = run_cargo_doc_md(&["-o", output_dir.to_str().unwrap()]);
+    // Run with --all-deps (may succeed or fail depending on dependencies)
+    let _ = run_cargo_doc_md(&["-o", output_dir.to_str().unwrap(), "--all-deps"]);
 
-    // Directory should now exist (even if command failed for other reasons)
-    // The converter creates the directory
+    // Key assertion: output directory should be created
+    assert!(output_dir.exists(), "Output directory should be created");
 
-    // Cleanup
     fs::remove_dir_all(&output_dir).ok();
 }


### PR DESCRIPTION
## Summary

This PR addresses the issue where LLM agents consistently guess the wrong file paths for dependency documentation. The solution flattens the directory structure and makes the CLI more intuitive.

## Major Changes

### 1. Flattened Directory Structure
**Before:**
```
target/doc-md/
  deps/
    tokio/index.md
    serde/index.md
```

**After:**
```
target/doc-md/
  tokio/index.md
  serde/index.md
```

- Dependencies now live directly in output directory alongside current crate
- More intuitive path structure (agents correctly guessed this in testing)
- Automatic migration removes old `deps/` directory with warning

### 2. Improved CLI Design

**New positional argument syntax:**
```bash
cargo doc-md tokio serde      # Document specific crates (NEW!)
cargo doc-md                  # Current crate + all deps
cargo doc-md --all-deps       # Only dependencies
```

**Explicit JSON conversion:**
```bash
cargo doc-md --json target/doc/my_crate.json
```

**Flag validation:**
- Prevents conflicting combinations (--all-deps + crate names, --json + crate names)
- Clear error messages guide users to correct usage

### 3. Better Output Messages

**Before:**
```
✓ Documentation complete! Output written to: target/doc-md/cargo-doc-md
✓ Documentation written to: target/doc-md/deps
```

**After:**
```
✓ Current crate documented: target/doc-md/cargo-doc-md/index.md
✓ anyhow → target/doc-md/anyhow/index.md
✓ serde → target/doc-md/serde/index.md
✓ Master index: target/doc-md/index.md
```

Users now see exact paths to entry point files.

### 4. Code Quality Improvements

- Non-fatal cleanup of old structure (doesn't block on permission issues)
- Robust root package lookup using `resolve.root`
- Master index generated in all code paths
- Better error messages with stderr summaries instead of suppression
- Validation of JSON file existence before processing

## Testing

- All existing tests pass
- Tested with 4 independent LLM agents - all correctly guessed new structure
- Validated flag conflicts work correctly
- Verified migration from old structure

## Breaking Changes

- Output directory structure changed (auto-migrated)
- CLI positional argument changed from JSON path to crate names
  - Use `--json` flag for JSON file conversion instead

## Migration

Users upgrading from v0.7.x will see:
```
⚠  Cleaning up old directory structure (target/doc-md/deps)
✓ Migrated to new flat structure
```

Old files automatically removed. No manual intervention required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
